### PR TITLE
Fix: Check whether mimetype being detected. Do not proceed if it's not det…

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,8 +39,7 @@ module.exports = function(options) {
             
             const imagePath = path.join(fileBase, src);
             const mimeType = mime.getType(imagePath);
-    
-            if (mimeType != 'application/octet-stream') {
+            if (mimeType && mimeType != 'application/octet-stream') {
     
                 const base64 = createBase64(imagePath);
     


### PR DESCRIPTION
I'm trying to fix this issue in the package. If the image src is not a valid file path(e.g. a placeholder of golang {{.image_link}}), it should be ignored. 
```golang
<img src="{{.image_link}}"/>
```